### PR TITLE
Fix issue #41 - Prevent snow from falling on blocks

### DIFF
--- a/src/main/java/com/elytradev/architecture/common/block/BlockShape.java
+++ b/src/main/java/com/elytradev/architecture/common/block/BlockShape.java
@@ -167,8 +167,7 @@ public class BlockShape extends BlockArchitecture<TileShape> {
     }
 
     @Override
-    public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face)
-    {
+    public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
         return BlockFaceShape.UNDEFINED;
     }
 

--- a/src/main/java/com/elytradev/architecture/common/block/BlockShape.java
+++ b/src/main/java/com/elytradev/architecture/common/block/BlockShape.java
@@ -167,6 +167,12 @@ public class BlockShape extends BlockArchitecture<TileShape> {
     }
 
     @Override
+    public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face)
+    {
+        return BlockFaceShape.UNDEFINED;
+    }
+
+    @Override
     public RayTraceResult collisionRayTrace(IBlockState state, World world, BlockPos pos, Vec3d start, Vec3d end) {
         RayTraceResult result = null;
         double nearestDistance = 0;


### PR DESCRIPTION
Returning false from isFullCube no longer prevents snow from landing on a block. Instead getBlockFaceShape is needed