### PR TITLE
Quickfix for #80

### DIFF
--- a/src/main/java/com/elytradev/architecture/common/tile/TileShape.java
+++ b/src/main/java/com/elytradev/architecture/common/tile/TileShape.java
@@ -270,11 +270,11 @@ public class TileShape extends TileArchitecture {
     }
 
     public boolean hasBaseBlockState() {
-        return this.baseBlockState.getBlock() != Blocks.AIR;
+        return this.baseBlockState == null ? false : this.baseBlockState.getBlock() != Blocks.AIR;
     }
 
     public boolean hasSecondaryBlockState() {
-        return this.secondaryBlockState.getBlock() != Blocks.AIR;
+        return this.secondaryBlockState == null ? false : this.secondaryBlockState.getBlock() != Blocks.AIR;
     }
 
     public boolean hasShape() {


### PR DESCRIPTION
Fixes #80 
This does not fix the issue that the secodary block state is null after removing the glass pane, But it should stop the server from crashing.