### PR TITLE
[1.12] Fix crash when interacting with window frame (Close #80)

### DIFF
--- a/src/main/java/com/elytradev/architecture/common/shape/ShapeKind.java
+++ b/src/main/java/com/elytradev/architecture/common/shape/ShapeKind.java
@@ -163,7 +163,7 @@ public abstract class ShapeKind {
             if (stack != null) {
                 if (!Utils.playerIsInCreativeMode(player))
                     Block.spawnAsEntity(te.getWorld(), te.getPos(), stack);
-                te.setSecondaryMaterial(null);
+                te.setSecondaryMaterial(Blocks.AIR.getDefaultState());
             }
         }
     }


### PR DESCRIPTION
Sorry for the double pull request. Here is an accual fix for #80 
Fixed TileShapes secondary block state beeing null after material was removed by setting it to Air instead of null.