### PR TITLE
Remove incorrect gl usage

### DIFF
--- a/src/main/java/com/elytradev/architecture/client/render/RenderingManager.java
+++ b/src/main/java/com/elytradev/architecture/client/render/RenderingManager.java
@@ -375,11 +375,6 @@ public class RenderingManager {
                     rend = RenderingManager.this.getCustomRendererForState(block.getDefaultState());
             }
             if (rend != null) {
-                try {
-                    GlStateManager.shadeModel(GL_SMOOTH);
-                } catch (RuntimeException e) {
-                    ArchitectureLog.warn("Failed to enable smooth shading for item models, {}", e.getMessage());
-                }
                 RenderTargetBaked target = new RenderTargetBaked();
                 rend.renderItemStack(stack, target, itemTrans);
                 return target.getBakedModel();


### PR DESCRIPTION
This pr is fixing an incompatibility with lwjgl3

```java
FATAL ERROR in native method: Thread[#201,Chunk Render Task Executor #0,3,main]: No context is current or a function that is not available in the current context was called. The JVM will abort execution.
    at org.lwjgl3.opengl.GL11.glShadeModel(Native Method)
    at org.lwjgl.opengl.GL11.glShadeModel(GL11.java:1551)
    at net.minecraft.client.renderer.GlStateManager.func_179103_j(SourceFile:529)
    at com.elytradev.architecture.client.render.RenderingManager$CustomItemRenderOverrideList.handleItemState(RenderingManager.java:379)
    at net.minecraft.client.renderer.RenderItem.func_184393_a(RenderItem.java:248)
    at codechicken.lib.render.item.CCRenderItem.func_184393_a(CCRenderItem.java:393)
    at slimeknights.tconstruct.library.client.model.ModelHelper.getBakedModelForItem(ModelHelper.java:61)
```